### PR TITLE
Add support for cloud providers different than Amazon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ hs_err_pid*
 pom.xml.releaseBackup
 release.properties
 *.iml
+
+# eclipse
+.project
+.classpath
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.22.0</version>
+      <version>4.7.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/github/kulminaator/s3/PicoClient.java
+++ b/src/main/java/com/github/kulminaator/s3/PicoClient.java
@@ -28,16 +28,18 @@ public class PicoClient implements Client {
 
     private boolean https;
     private final String region;
+    private final String host;
     private HttpClient httpClient;
     private CredentialsProvider credentialsProvider;
     private int connectTimeout;
     private int readTimeout;
 
-    private PicoClient(String region) {
-        this.region = region;
-    }
+    private PicoClient(String region, String host) {
+		this.region = region;
+		this.host = host;
+	}
 
-    @Override
+	@Override
     public S3Object getObject(String bucket, String object) throws S3AccessException {
         final Map<String,List<String>> headers = new HashMap<>();
         final HttpRequest request = this.buildRequestBase("HEAD", bucket);
@@ -207,7 +209,7 @@ public class PicoClient implements Client {
         builder.append(bucket);
         builder.append(".s3.");
         builder.append(region);
-        builder.append(".amazonaws.com");
+        builder.append("." + host);
         return builder.toString();
     }
 
@@ -295,6 +297,7 @@ public class PicoClient implements Client {
     public static class Builder {
 
         private String region;
+        private String host = "amazonaws.com";
         private boolean https = true;
         private HttpClient httpClient = new PicoHttpClient();
         private CredentialsProvider credentialsProvider;
@@ -317,6 +320,11 @@ public class PicoClient implements Client {
             this.region = region;
             return this;
         }
+        
+        public Builder withHost(String host) {
+        	this.host = host;
+            return this;
+		}
 
         public Builder withCredentialsProvider(CredentialsProvider credentialsProvider) {
             this.credentialsProvider = credentialsProvider;
@@ -350,7 +358,7 @@ public class PicoClient implements Client {
         }
 
         public PicoClient build() {
-            final PicoClient client = new PicoClient(this.region);
+            final PicoClient client = new PicoClient(this.region, this.host);
             client.setHttps(this.https);
             client.setHttpClient(this.httpClient);
             client.setCredentialsProvider(this.credentialsProvider);

--- a/src/test/java/com/github/kulminaator/s3/integrationtest/RealLifeTest.java
+++ b/src/test/java/com/github/kulminaator/s3/integrationtest/RealLifeTest.java
@@ -27,8 +27,11 @@ public class RealLifeTest {
     private String accessKeyId;
     private String secretAccessKeyId;
     private String sessionToken;
+    private String region;
+    private String host;
     private String testObject;
     private String publicBucketName;
+	private String bigListNumber;
 
     @Before
     public void parseEnv() {
@@ -44,6 +47,9 @@ public class RealLifeTest {
         this.accessKeyId = System.getenv("PICO_TEST_ACCESS_KEY");
         this.secretAccessKeyId = System.getenv("PICO_TEST_SECRET_KEY");
         this.sessionToken = System.getenv("PICO_TEST_SESSION_TOKEN");
+        this.region = System.getenv("PICO_TEST_REGION");
+        this.host = System.getenv("PICO_TEST_HOST");
+        this.bigListNumber = System.getenv("PICO_TEST_BIG_LIST_NUMBER");
     }
 
     @Test
@@ -51,13 +57,15 @@ public class RealLifeTest {
         if (this.noEnv()) { assertTrue("Skipped", true); return;}
         final Client pClient = new PicoClient.Builder()
                 .withHttpClient(new PicoHttpClient(true))
-                .withRegion("eu-west-1")
+                .withRegion(region)
+                .withHost(host)
                 .build();
 
         // list the "root folder", as in no prefix
         List<S3Object> objects = pClient.listObjects(this.publicBucketName, null);
 
-        assertTrue(objects.size() > 1200);
+        int expectedListSize = (bigListNumber == null || bigListNumber.isBlank()) ?  1200 : Integer.parseInt(bigListNumber);
+        assertTrue(objects.size() > expectedListSize);
     }
 
     @Test
@@ -65,7 +73,8 @@ public class RealLifeTest {
         if (this.noEnv()) { assertTrue("Skipped", true); return;}
         final Client pClient = new PicoClient.Builder()
                 .withHttpClient(new PicoHttpClient(true))
-                .withRegion("eu-west-1")
+                .withRegion(region)
+                .withHost(host)
                 .withReadTimeout(1)
                 .withConnectTimeout(1)
                 .build();
@@ -87,7 +96,8 @@ public class RealLifeTest {
         if (this.noEnv()) { assertTrue("Skipped", true); return;}
         final Client pClient = new PicoClient.Builder()
                 .withHttpClient(new PicoHttpClient(true))
-                .withRegion("eu-west-1")
+                .withRegion(region)
+                .withHost(host)
                 .build();
 
         // list the "root folder", as in no prefix
@@ -102,7 +112,8 @@ public class RealLifeTest {
         if (this.noEnv()) { assertTrue("Skipped", true); return;}
         final Client pClient = new PicoClient.Builder()
                 .withHttpClient(new PicoHttpClient(true))
-                .withRegion("eu-west-1")
+                .withRegion(region)
+                .withHost(host)
                 .build();
 
         // list the "root folder", as in no prefix
@@ -116,7 +127,8 @@ public class RealLifeTest {
         if (this.noEnv()) { assertTrue("Skipped", true); return;}
         final Client pClient = new PicoClient.Builder()
                 .withHttpClient(new PicoHttpClient(true))
-                .withRegion("eu-west-1")
+                .withRegion(region)
+                .withHost(host)
                 .build();
 
         // list the "root folder", as in no prefix
@@ -139,7 +151,8 @@ public class RealLifeTest {
         if (this.noEnv()) { assertTrue("Skipped", true); return;}
         final Client pClient = new PicoClient.Builder()
                 .withHttpClient(new PicoHttpClient(true))
-                .withRegion("eu-west-1")
+                .withRegion(region)
+                .withHost(host)
                 .build();
         final String data =
                 pClient.getObjectDataAsString(this.bucketName, "public-read-folder/anyone_can_read_this.txt");
@@ -159,7 +172,8 @@ public class RealLifeTest {
         final Client pClient = new PicoClient.Builder()
                 .withHttpClient(new PicoHttpClient(true))
                 .withCredentialsProvider(simpleCredentialsProvider)
-                .withRegion("eu-west-1")
+                .withRegion(region)
+                .withHost(host)
                 .build();
 
         byte[] randomData = this.buildRandomXmlData();
@@ -175,7 +189,9 @@ public class RealLifeTest {
 
     @Test
     public void put_object_with_simple_credentials_and_crypto() throws Exception {
-        if (this.noEnv()) { assertTrue("Skipped", true); return;}
+        
+    	// Scaleway doesn't support server side crypto
+    	if (this.noEnv() || this.host.equals("scw.cloud")) { assertTrue("Skipped", true); return;}
 
         final SimpleCredentialsProvider simpleCredentialsProvider = new SimpleCredentialsProvider();
         simpleCredentialsProvider.setAccessKeyId(this.accessKeyId);
@@ -185,7 +201,8 @@ public class RealLifeTest {
         final Client pClient = new PicoClient.Builder()
                 .withHttpClient(new PicoHttpClient(true))
                 .withCredentialsProvider(simpleCredentialsProvider)
-                .withRegion("eu-west-1")
+                .withRegion(region)
+                .withHost(host)
                 .build();
 
         byte[] randomData = this.buildRandomXmlData();
@@ -230,7 +247,8 @@ public class RealLifeTest {
         simpleCredentialsProvider.setSessionToken(this.sessionToken);
 
         final Client pClient = new PicoClient.Builder()
-                .withRegion("eu-west-1")
+                .withRegion(region)
+                .withHost(host)
                 .withCredentialsProvider(simpleCredentialsProvider)
                 .build();
         final List<S3Object> objects = pClient.listObjects(this.bucketName);
@@ -250,7 +268,8 @@ public class RealLifeTest {
         simpleCredentialsProvider.setSessionToken(this.sessionToken);
 
         final Client pClient = new PicoClient.Builder()
-                .withRegion("eu-west-1")
+                .withRegion(region)
+                .withHost(host)
                 .withCredentialsProvider(simpleCredentialsProvider)
                 .build();
         final List<S3Object> objects = pClient.listObjects(this.publicBucketName);

--- a/test_with_env-example.sh
+++ b/test_with_env-example.sh
@@ -12,6 +12,9 @@ export PICO_TEST_OBJECT="some-bucket-object"
 export PICO_TEST_ACCESS_KEY="some-access-key"
 export PICO_TEST_SECRET_KEY="some-secret-key"
 export PICO_TEST_SESSION_TOKEN="some-session-token"
+export PICO_TEST_REGION="some-region"
+export PICO_TEST_HOST="some-cloud-provider-supporting-s3"
+export PICO_TEST_BIG_LIST_NUMBER="6"
 
 
 mvn test


### PR DESCRIPTION
This pull request aims to let users change the hostname, which was hard coded. That way  this library can be used with other providers apart from AWS that support the S3 protocol (in my case Scaleway). 

Also, when running the tests on Windows some  issues where found on 4 tests and fixed.

Finally, Mockito was updated to the latest version.